### PR TITLE
chore: /api global prefix + changed swagger endpoint to /api/spec

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - /app/node_modules
     ports:
       - 3000:3000
+      - 3030:3030
     depends_on:
       - emsp-backend-db
     environment:

--- a/packages/emsp-backend/src/main.ts
+++ b/packages/emsp-backend/src/main.ts
@@ -6,15 +6,16 @@ import { LoggerService } from './logger/logger.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api')
 
   const logger = app.get(LoggerService);
 
   const api = new DocumentBuilder().setTitle('ReBeam eMSP Backend').build();
   const document = SwaggerModule.createDocument(app, api);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api/spec', app, document);
 
-  logger.log(`OpenAPI UI mapped to /api`, SwaggerModule.name);
-  logger.log('OpenAPI spec mapped to /api-json', SwaggerModule.name);
+  logger.log(`OpenAPI UI mapped to /api/spec`, SwaggerModule.name);
+  logger.log('OpenAPI spec mapped to /api/spec-json', SwaggerModule.name);
 
   const config = app.get(ConfigService);
   const port = +config.get('server.port');


### PR DESCRIPTION
- use global `/api` prefix
- change swagger path from `/api` to `/api/spec`
- open ocpi server port in docker-compose.yml